### PR TITLE
Add support for bonding

### DIFF
--- a/.jitpack.yml
+++ b/.jitpack.yml
@@ -1,0 +1,2 @@
+jdk:
+  - openjdk17

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -9,7 +9,6 @@ plugins {
     alias(libs.plugins.kotlin.multiplatform) apply false
     alias(libs.plugins.android.library) apply false
     alias(libs.plugins.kotlinter) apply false
-    alias(libs.plugins.maven.publish) apply false
     alias(libs.plugins.atomicfu) apply false
     alias(libs.plugins.dokka)
     alias(libs.plugins.api)

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -30,4 +30,3 @@ atomicfu = { id = "org.jetbrains.kotlinx.atomicfu", version.ref = "atomicfu" }
 dokka = { id = "org.jetbrains.dokka", version = "1.9.20" }
 kotlin-multiplatform = { id = "org.jetbrains.kotlin.multiplatform", version.ref = "kotlin" }
 kotlinter = { id = "org.jmailen.kotlinter", version = "4.4.1" }
-maven-publish = { id = "com.vanniktech.maven.publish", version = "0.29.0" }

--- a/kable-core/api/android/kable-core.api
+++ b/kable-core/api/android/kable-core.api
@@ -13,12 +13,22 @@ public abstract interface class com/juul/kable/Advertisement {
 
 public abstract interface class com/juul/kable/AndroidPeripheral : com/juul/kable/Peripheral {
 	public abstract fun getAddress ()Ljava/lang/String;
+	public abstract fun getBondState ()Lkotlinx/coroutines/flow/Flow;
 	public abstract fun getMtu ()Lkotlinx/coroutines/flow/StateFlow;
 	public abstract fun getType ()Lcom/juul/kable/AndroidPeripheral$Type;
 	public abstract fun requestConnectionPriority (Lcom/juul/kable/AndroidPeripheral$Priority;)Z
 	public abstract fun requestMtu (ILkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public abstract fun write (Lcom/juul/kable/Characteristic;[BLcom/juul/kable/WriteType;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public abstract fun write (Lcom/juul/kable/Descriptor;[BLkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
+public final class com/juul/kable/AndroidPeripheral$Bond : java/lang/Enum {
+	public static final field Bonded Lcom/juul/kable/AndroidPeripheral$Bond;
+	public static final field Bonding Lcom/juul/kable/AndroidPeripheral$Bond;
+	public static final field None Lcom/juul/kable/AndroidPeripheral$Bond;
+	public static fun getEntries ()Lkotlin/enums/EnumEntries;
+	public static fun valueOf (Ljava/lang/String;)Lcom/juul/kable/AndroidPeripheral$Bond;
+	public static fun values ()[Lcom/juul/kable/AndroidPeripheral$Bond;
 }
 
 public final class com/juul/kable/AndroidPeripheral$Priority : java/lang/Enum {

--- a/kable-core/build.gradle.kts
+++ b/kable-core/build.gradle.kts
@@ -6,7 +6,7 @@ plugins {
     alias(libs.plugins.atomicfu)
     id("org.jmailen.kotlinter")
     id("org.jetbrains.dokka")
-    id("com.vanniktech.maven.publish")
+    id("maven-publish")
 }
 
 kotlin {

--- a/kable-core/src/androidMain/kotlin/AndroidPeripheral.kt
+++ b/kable-core/src/androidMain/kotlin/AndroidPeripheral.kt
@@ -7,6 +7,7 @@ import android.bluetooth.BluetoothGatt
 import android.bluetooth.BluetoothStatusCodes
 import android.os.Build
 import androidx.annotation.RequiresPermission
+import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.StateFlow
 
 @Deprecated(
@@ -19,6 +20,8 @@ public typealias Priority = AndroidPeripheral.Priority
 public interface AndroidPeripheral : Peripheral {
 
     public enum class Priority { Low, Balanced, High }
+
+    public enum class Bond { None, Bonding, Bonded }
 
     public enum class Type {
 
@@ -160,4 +163,6 @@ public interface AndroidPeripheral : Peripheral {
      * is negotiated.
      */
     public val mtu: StateFlow<Int?>
+
+    public val bondState: Flow<Bond>
 }

--- a/kable-core/src/androidMain/kotlin/Connection.kt
+++ b/kable-core/src/androidMain/kotlin/Connection.kt
@@ -1,7 +1,10 @@
 package com.juul.kable
 
 import android.bluetooth.BluetoothGatt
+import android.bluetooth.BluetoothGatt.GATT_INSUFFICIENT_AUTHENTICATION
+import android.bluetooth.BluetoothGatt.GATT_INSUFFICIENT_ENCRYPTION
 import android.bluetooth.BluetoothGatt.GATT_SUCCESS
+import com.juul.kable.external.GATT_AUTH_FAIL
 import com.juul.kable.gatt.Callback
 import com.juul.kable.gatt.GattStatus
 import com.juul.kable.gatt.Response
@@ -19,7 +22,14 @@ public class OutOfOrderGattCallbackException internal constructor(
     message: String,
 ) : IllegalStateException(message)
 
-private val GattSuccess = GattStatus(GATT_SUCCESS)
+internal class BondRequiredException : IllegalStateException()
+
+private val Success = GattStatus(GATT_SUCCESS)
+private val BondingStatuses = listOf(
+    GattStatus(GATT_AUTH_FAIL),
+    GattStatus(GATT_INSUFFICIENT_AUTHENTICATION),
+    GattStatus(GATT_INSUFFICIENT_ENCRYPTION),
+)
 
 internal class Connection(
     private val scope: CoroutineScope,
@@ -48,6 +58,7 @@ internal class Connection(
      * `Handler` is used (and is also used in the Android BLE [Callback]).
      *
      * @throws GattStatusException if response has a non-`GATT_SUCCESS` status.
+     * @throws BondRequiredException if [action] requires authentication (i.e. bonding).
      */
     suspend inline fun <reified T> execute(
         crossinline action: BluetoothGatt.() -> Unit,
@@ -89,14 +100,17 @@ internal class Connection(
         }
         deferredResponse = null
 
-        if (response.status != GattSuccess) throw GattStatusException(response.toString())
-
-        // `lock` should always enforce a 1:1 matching of request to response, but if an Android `BluetoothGattCallback`
-        // method gets called out of order then we'll cast to the wrong response type.
-        response as? T
-            ?: throw OutOfOrderGattCallbackException(
-                "Unexpected response type ${response.javaClass.simpleName} received",
-            )
+        when (response.status) {
+            // `lock` should always enforce a 1:1 matching of request to response, but if an Android `BluetoothGattCallback`
+            // method gets called out of order then we'll cast to the wrong response type.
+            Success ->
+                response as? T
+                    ?: throw OutOfOrderGattCallbackException(
+                        "Unexpected response type ${response.javaClass.simpleName} received",
+                    )
+            in BondingStatuses -> throw BondRequiredException()
+            else -> throw GattStatusException(response.toString())
+        }
     }
 
     /**
@@ -120,7 +134,7 @@ internal class Connection(
             throw ConnectionLostException(cause = e)
         }
 
-        if (response.status != GattSuccess) throw GattStatusException(response.toString())
+        if (response.status != Success) throw GattStatusException(response.toString())
         response.mtu
     }
 }

--- a/kable-exceptions/build.gradle.kts
+++ b/kable-exceptions/build.gradle.kts
@@ -2,7 +2,7 @@ plugins {
     kotlin("multiplatform")
     id("org.jmailen.kotlinter")
     id("org.jetbrains.dokka")
-    id("com.vanniktech.maven.publish")
+    id("maven-publish")
 }
 
 kotlin {

--- a/kable-log-engine-khronicle/build.gradle.kts
+++ b/kable-log-engine-khronicle/build.gradle.kts
@@ -2,7 +2,7 @@ plugins {
     kotlin("multiplatform")
     id("org.jmailen.kotlinter")
     id("org.jetbrains.dokka")
-    id("com.vanniktech.maven.publish")
+    id("maven-publish")
 }
 
 kotlin {


### PR DESCRIPTION
<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

Add support for Bluetooth bonding in the Android peripheral, enabling secure connections by managing bond state changes and handling bond-required exceptions during Bluetooth operations.

New Features:
- Introduce support for Bluetooth bonding in the Android peripheral implementation, allowing devices to establish a secure connection by handling bond state changes.

Enhancements:
- Add a mechanism to handle bond-required exceptions during Bluetooth operations, ensuring that read and write actions are retried after bonding is completed.

<!-- Generated by sourcery-ai[bot]: end summary -->