### PR TITLE
Add bondedDevices flow

### DIFF
--- a/kable-core/api/android/kable-core.api
+++ b/kable-core/api/android/kable-core.api
@@ -65,6 +65,7 @@ public final class com/juul/kable/AndroidPeripheral$WriteResult : java/lang/Enum
 public final class com/juul/kable/Bluetooth {
 	public static final field INSTANCE Lcom/juul/kable/Bluetooth;
 	public final fun getAvailability ()Lkotlinx/coroutines/flow/Flow;
+	public final fun getBondedDevices ()Lkotlinx/coroutines/flow/Flow;
 	public final fun isSupported (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }
 

--- a/kable-core/api/jvm/kable-core.api
+++ b/kable-core/api/jvm/kable-core.api
@@ -14,6 +14,7 @@ public abstract interface class com/juul/kable/Advertisement {
 public final class com/juul/kable/Bluetooth {
 	public static final field INSTANCE Lcom/juul/kable/Bluetooth;
 	public final fun getAvailability ()Lkotlinx/coroutines/flow/Flow;
+	public final fun getBondedDevices ()Lkotlinx/coroutines/flow/Flow;
 	public final fun isSupported (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }
 
@@ -67,6 +68,10 @@ public abstract interface class com/juul/kable/Descriptor {
 	public abstract fun getCharacteristicUuid ()Ljava/util/UUID;
 	public abstract fun getDescriptorUuid ()Ljava/util/UUID;
 	public abstract fun getServiceUuid ()Ljava/util/UUID;
+}
+
+public final class com/juul/kable/Device {
+	public fun <init> ()V
 }
 
 public final class com/juul/kable/DiscoveredCharacteristic : com/juul/kable/Characteristic {

--- a/kable-core/src/androidMain/kotlin/Bluetooth.kt
+++ b/kable-core/src/androidMain/kotlin/Bluetooth.kt
@@ -6,6 +6,8 @@ import android.bluetooth.BluetoothAdapter.STATE_OFF
 import android.bluetooth.BluetoothAdapter.STATE_ON
 import android.bluetooth.BluetoothAdapter.STATE_TURNING_OFF
 import android.bluetooth.BluetoothAdapter.STATE_TURNING_ON
+import android.bluetooth.BluetoothDevice
+import android.bluetooth.BluetoothDevice.ACTION_BOND_STATE_CHANGED
 import android.bluetooth.BluetoothManager
 import android.content.Context
 import android.content.IntentFilter
@@ -49,6 +51,8 @@ public actual enum class Reason {
     /** Only applicable on Android 11 (API 30) and lower. */
     LocationServicesDisabled,
 }
+
+public actual typealias Device = BluetoothDevice
 
 private fun Context.getLocationManagerOrNull() =
     ContextCompat.getSystemService(this, LocationManager::class.java)
@@ -103,3 +107,8 @@ internal actual val bluetoothAvailability: Flow<Bluetooth.Availability> =
             null -> Unavailable(reason = AdapterNotAvailable)
         }
     }
+
+internal actual val bluetoothBondedDevices: Flow<List<BluetoothDevice>> =
+    broadcastReceiverFlow(IntentFilter(ACTION_BOND_STATE_CHANGED), RECEIVER_EXPORTED)
+        .map { getBluetoothAdapter().bondedDevices.toList() }
+        .onStart { emit(getBluetoothAdapter().bondedDevices.toList()) }

--- a/kable-core/src/appleMain/kotlin/Bluetooth.kt
+++ b/kable-core/src/appleMain/kotlin/Bluetooth.kt
@@ -10,6 +10,7 @@ import com.juul.kable.Reason.Unsupported
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.emitAll
 import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.flow.map
 import platform.CoreBluetooth.CBCentralManagerStatePoweredOff
 import platform.CoreBluetooth.CBCentralManagerStatePoweredOn
@@ -26,6 +27,8 @@ public actual enum class Reason {
     Unknown, // CBManagerState.unknown
 }
 
+public actual class Device
+
 internal actual val bluetoothAvailability: Flow<Bluetooth.Availability> = flow {
     // flow + emitAll dance so that lazy `CentralManager.Default` is not initialized until this flow is active.
     emitAll(CentralManager.Default.delegate.state)
@@ -39,3 +42,5 @@ internal actual val bluetoothAvailability: Flow<Bluetooth.Availability> = flow {
         else -> Unavailable(reason = Unknown)
     }
 }
+
+internal actual val bluetoothBondedDevices: Flow<List<Device>> = flowOf()

--- a/kable-core/src/commonMain/kotlin/Bluetooth.kt
+++ b/kable-core/src/commonMain/kotlin/Bluetooth.kt
@@ -9,6 +9,8 @@ import com.juul.kable.bluetooth.isSupported as isBluetoothSupported
 
 public expect enum class Reason
 
+public expect class Device
+
 public object Bluetooth {
 
     /**
@@ -45,6 +47,10 @@ public object Bluetooth {
     public suspend fun isSupported(): Boolean = isBluetoothSupported()
 
     public val availability: Flow<Availability> = bluetoothAvailability
+
+    public val bondedDevices: Flow<List<Device>> = bluetoothBondedDevices
 }
 
 internal expect val bluetoothAvailability: Flow<Bluetooth.Availability>
+
+internal expect val bluetoothBondedDevices: Flow<List<Device>>

--- a/kable-core/src/jsMain/kotlin/BluetoothAvailability.kt
+++ b/kable-core/src/jsMain/kotlin/BluetoothAvailability.kt
@@ -17,6 +17,8 @@ public actual enum class Reason {
     BluetoothUndefined,
 }
 
+public actual class Device
+
 private const val AVAILABILITY_CHANGED = "availabilitychanged"
 
 internal actual val bluetoothAvailability: Flow<Bluetooth.Availability> =
@@ -40,3 +42,5 @@ internal actual val bluetoothAvailability: Flow<Bluetooth.Availability> =
             emit(availability)
         }
     } ?: flowOf(Unavailable(reason = BluetoothUndefined))
+
+internal actual val bluetoothBondedDevices: Flow<List<Device>> = flowOf()

--- a/kable-core/src/jvmMain/kotlin/com/juul/kable/Bluetooth.kt
+++ b/kable-core/src/jvmMain/kotlin/com/juul/kable/Bluetooth.kt
@@ -6,4 +6,8 @@ public actual enum class Reason {
     // Not implemented.
 }
 
+public actual class Device
+
 internal actual val bluetoothAvailability: Flow<Bluetooth.Availability> = jvmNotImplementedException()
+
+internal actual val bluetoothBondedDevices: Flow<List<Device>> = jvmNotImplementedException()


### PR DESCRIPTION
<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

Add a new flow to track bonded Bluetooth devices, allowing retrieval of a list of bonded devices across Android, Apple, JS, and JVM platforms. Introduce a unified Device class to represent Bluetooth devices consistently.

New Features:
- Introduce a new flow to track bonded Bluetooth devices across different platforms, providing a list of bonded devices.

Enhancements:
- Add a typealias for BluetoothDevice as Device to unify the representation of devices across platforms.

<!-- Generated by sourcery-ai[bot]: end summary -->